### PR TITLE
Fix bugs and clean toml config parsing

### DIFF
--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -11,7 +11,7 @@ class ConfigParsingException(Exception):
     pass
 
 
-def __parse_enum(table: dict, key: str, enum: Any, default: int = 0) -> Any:
+def __enum(table: dict, key: str, enum: Any, default: int = 0) -> Any:
     if key not in table:
         return enum(default)
     try:
@@ -19,7 +19,50 @@ def __parse_enum(table: dict, key: str, enum: Any, default: int = 0) -> Any:
             if str(enum(i)).split('.')[-1].lower() == table[key].lower():
                 return enum(i)
     except ValueError:
-        raise ConfigParsingException(f"Invalid value \"{table[key]}\" for key \"{key}\".")
+        raise ConfigParsingException(f"Invalid value {repr(table[key])} for key '{key}'.")
+
+
+def __str(table: dict, key: str, default: str = "") -> str:
+    v = table.get(key, default)
+    if isinstance(v, str):
+        return v
+    raise ConfigParsingException(f"'{key}' has value {repr(v)}. Expected a string.")
+
+
+def __bool(table: dict, key: str, default: bool = False) -> bool:
+    v = table.get(key, default)
+    if isinstance(v, bool):
+        return v
+    raise ConfigParsingException(f"'{key}' has value {repr(v)}. Expected a bool.")
+
+
+def __int(table: dict, key: str, default: int = 0) -> int:
+    v = table.get(key, default)
+    if isinstance(v, int):
+        return v
+    raise ConfigParsingException(f"'{key}' has value {repr(v)}. Expected an int.")
+
+
+def __table(table: dict, key: str) -> dict:
+    v = table.get(key, dict())
+    if isinstance(v, dict):
+        return v
+    raise ConfigParsingException(f"'{key}' has value {repr(v)}. Expected a table.")
+
+
+def __team(table: dict) -> int:
+    if 'team' not in table:
+        return 0
+    v = table['team']
+    if isinstance(v, str):
+        if v.lower() == "blue":
+            return 0
+        if v.lower() == "orange":
+            return 1
+    if isinstance(v, int):
+        if 0 <= v <= 1:
+            return v
+    raise ConfigParsingException(f"'team' has value {repr(v)}. Expected a 0, 1, \"blue\", or \"orange\".")
 
 
 def load_match_config(config_path: Path | str) -> flat.MatchConfiguration:
@@ -30,25 +73,18 @@ def load_match_config(config_path: Path | str) -> flat.MatchConfiguration:
     with open(config_path, "rb") as f:
         config = tomllib.load(f)
 
-    rlbot_table = config.get("rlbot", dict())
-    match_table = config.get("match", dict())
-    mutator_table = config.get("mutators", dict())
+    rlbot_table = __table(config, "rlbot")
+    match_table = __table(config, "match")
+    mutator_table = __table(config, "mutators")
 
     players = []
     for car_table in config.get("cars", []):
-        car_config = car_table.get("config")
-        name = car_table.get("name", "")
-        team = car_table.get("team", 0)
-        try:
-            team = int(team)
-        except ValueError:
-            team = {"blue": 0, "orange": 1}.get(team.lower())
-        if team is None or team not in [0, 1]:
-            raise ConfigParsingException(f"Invalid team \"{car_table.get("team")}\" for player {len(players)}.")
-
-        loadout_file = car_table.get("loadout_file")
-        skill = __parse_enum(car_table, "skill", flat.PsyonixSkill, int(flat.PsyonixSkill.AllStar))
-        variant = car_table.get("type", "rlbot").lower()
+        car_config = __str(car_table, "config")
+        name = __str(car_table, "name")
+        team = __team(car_table)
+        loadout_file = __str(car_table, "loadout_file") or None
+        skill = __enum(car_table, "skill", flat.PsyonixSkill, int(flat.PsyonixSkill.AllStar))
+        variant = __str(car_table, "type", "rlbot").lower()
 
         match variant:
             case "rlbot":
@@ -61,9 +97,9 @@ def load_match_config(config_path: Path | str) -> flat.MatchConfiguration:
                 logger.warning("PartyMember player type is not supported yet.")
                 variety, use_config = flat.PartyMember, False
             case t:
-                raise ConfigParsingException(f"Invalid player type \"{t}\" for player {len(players)}.")
+                raise ConfigParsingException(f"Invalid player type {repr(t)} for player {len(players)}.")
 
-        if use_config and car_config is not None:
+        if use_config and car_config:
             abs_config_path = (config_path.parent / car_config).resolve()
             players.append(load_player_config(abs_config_path, variety, team, name, loadout_file))
         else:
@@ -72,50 +108,50 @@ def load_match_config(config_path: Path | str) -> flat.MatchConfiguration:
 
     scripts = []
     for script_table in config.get("scripts", []):
-        if script_config := script_table.get("config"):
+        if script_config := __str(script_table, "config"):
             abs_config_path = (config_path.parent / script_config).resolve()
             scripts.append(load_script_config(abs_config_path))
         else:
             scripts.append(flat.ScriptConfiguration())
 
     mutators = flat.MutatorSettings(
-        match_length=__parse_enum(mutator_table, "match_length", flat.MatchLengthMutator),
-        max_score=__parse_enum(mutator_table, "max_score", flat.MaxScoreMutator),
-        multi_ball=__parse_enum(mutator_table, "multi_ball", flat.MultiBallMutator),
-        overtime=__parse_enum(mutator_table, "overtime", flat.OvertimeMutator),
-        series_length=__parse_enum(mutator_table, "series_length", flat.SeriesLengthMutator),
-        game_speed=__parse_enum(mutator_table, "game_speed", flat.GameSpeedMutator),
-        ball_max_speed=__parse_enum(mutator_table, "ball_max_speed", flat.BallMaxSpeedMutator),
-        ball_type=__parse_enum(mutator_table, "ball_type", flat.BallTypeMutator),
-        ball_weight=__parse_enum(mutator_table, "ball_weight", flat.BallWeightMutator),
-        ball_size=__parse_enum(mutator_table, "ball_size", flat.BallSizeMutator),
-        ball_bounciness=__parse_enum(mutator_table, "ball_bounciness", flat.BallBouncinessMutator),
-        boost=__parse_enum(mutator_table, "boost_amount", flat.BoostMutator),
-        rumble=__parse_enum(mutator_table, "rumble", flat.RumbleMutator),
-        boost_strength=__parse_enum(mutator_table, "boost_strength", flat.BoostStrengthMutator),
-        gravity=__parse_enum(mutator_table, "gravity", flat.GravityMutator),
-        demolish=__parse_enum(mutator_table, "demolish", flat.DemolishMutator),
-        respawn_time=__parse_enum(mutator_table, "respawn_time", flat.RespawnTimeMutator),
-        max_time=__parse_enum(mutator_table, "max_time", flat.MaxTimeMutator),
-        game_event=__parse_enum(mutator_table, "game_event", flat.GameEventMutator),
-        audio=__parse_enum(mutator_table, "audio", flat.AudioMutator),
+        match_length=__enum(mutator_table, "match_length", flat.MatchLengthMutator),
+        max_score=__enum(mutator_table, "max_score", flat.MaxScoreMutator),
+        multi_ball=__enum(mutator_table, "multi_ball", flat.MultiBallMutator),
+        overtime=__enum(mutator_table, "overtime", flat.OvertimeMutator),
+        series_length=__enum(mutator_table, "series_length", flat.SeriesLengthMutator),
+        game_speed=__enum(mutator_table, "game_speed", flat.GameSpeedMutator),
+        ball_max_speed=__enum(mutator_table, "ball_max_speed", flat.BallMaxSpeedMutator),
+        ball_type=__enum(mutator_table, "ball_type", flat.BallTypeMutator),
+        ball_weight=__enum(mutator_table, "ball_weight", flat.BallWeightMutator),
+        ball_size=__enum(mutator_table, "ball_size", flat.BallSizeMutator),
+        ball_bounciness=__enum(mutator_table, "ball_bounciness", flat.BallBouncinessMutator),
+        boost=__enum(mutator_table, "boost_amount", flat.BoostMutator),
+        rumble=__enum(mutator_table, "rumble", flat.RumbleMutator),
+        boost_strength=__enum(mutator_table, "boost_strength", flat.BoostStrengthMutator),
+        gravity=__enum(mutator_table, "gravity", flat.GravityMutator),
+        demolish=__enum(mutator_table, "demolish", flat.DemolishMutator),
+        respawn_time=__enum(mutator_table, "respawn_time", flat.RespawnTimeMutator),
+        max_time=__enum(mutator_table, "max_time", flat.MaxTimeMutator),
+        game_event=__enum(mutator_table, "game_event", flat.GameEventMutator),
+        audio=__enum(mutator_table, "audio", flat.AudioMutator),
     )
 
     return flat.MatchConfiguration(
-        launcher=__parse_enum(rlbot_table, "launcher", flat.Launcher),
-        launcher_arg=rlbot_table.get("launcher_arg", ""),
-        auto_start_bots=rlbot_table.get("auto_start_bots", True),
-        game_map_upk=match_table.get("game_map_upk", ""),
+        launcher=__enum(rlbot_table, "launcher", flat.Launcher),
+        launcher_arg=__str(rlbot_table, "launcher_arg"),
+        auto_start_bots=__bool(rlbot_table, "auto_start_bots", True),
+        game_map_upk=__str(match_table, "game_map_upk"),
         player_configurations=players,
         script_configurations=scripts,
-        game_mode=__parse_enum(match_table, "game_mode", flat.GameMode),
-        skip_replays=match_table.get("skip_replays", False),
-        instant_start=match_table.get("instant_start", False),
+        game_mode=__enum(match_table, "game_mode", flat.GameMode),
+        skip_replays=__bool(match_table, "skip_replays"),
+        instant_start=__bool(match_table, "instant_start"),
         mutators=mutators,
-        existing_match_behavior=__parse_enum(match_table, "existing_match_behavior", flat.ExistingMatchBehavior),
-        enable_rendering=match_table.get("enable_rendering", False),
-        enable_state_setting=match_table.get("enable_state_setting", False),
-        freeplay=match_table.get("freeplay", False),
+        existing_match_behavior=__enum(match_table, "existing_match_behavior", flat.ExistingMatchBehavior),
+        enable_rendering=__bool(match_table, "enable_rendering"),
+        enable_state_setting=__bool(match_table, "enable_state_setting"),
+        freeplay=__bool(match_table, "freeplay"),
     )
 
 
@@ -126,34 +162,35 @@ def load_player_loadout(path: Path | str, team: int) -> flat.PlayerLoadout:
     with open(path, "rb") as f:
         config = tomllib.load(f)
 
-    loadout = config["blue_loadout"] if team == 0 else config["orange_loadout"]
+    table_name = "blue_loadout" if team == 0 else "orange_loadout"
+    loadout = __table(config, table_name)
     paint = None
-    if paint_table := loadout.get("paint", None):
+    if paint_table := __table(loadout, "paint"):
         paint = flat.LoadoutPaint(
-            car_paint_id=paint_table.get("car_paint_id", 0),
-            decal_paint_id=paint_table.get("decal_paint_id", 0),
-            wheels_paint_id=paint_table.get("wheels_paint_id", 0),
-            boost_paint_id=paint_table.get("boost_paint_id", 0),
-            antenna_paint_id=paint_table.get("antenna_paint_id", 0),
-            hat_paint_id=paint_table.get("hat_paint_id", 0),
-            trails_paint_id=paint_table.get("trails_paint_id", 0),
-            goal_explosion_paint_id=paint_table.get("goal_explosion_paint_id", 0),
+            car_paint_id=__int(paint_table, "car_paint_id"),
+            decal_paint_id=__int(paint_table, "decal_paint_id"),
+            wheels_paint_id=__int(paint_table, "wheels_paint_id"),
+            boost_paint_id=__int(paint_table, "boost_paint_id"),
+            antenna_paint_id=__int(paint_table, "antenna_paint_id"),
+            hat_paint_id=__int(paint_table, "hat_paint_id"),
+            trails_paint_id=__int(paint_table, "trails_paint_id"),
+            goal_explosion_paint_id=__int(paint_table, "goal_explosion_paint_id"),
         )
 
     return flat.PlayerLoadout(
-        team_color_id=loadout.get("team_color_id", 0),
-        custom_color_id=loadout.get("custom_color_id", 0),
-        car_id=loadout.get("car_id", 0),
-        decal_id=loadout.get("decal_id", 0),
-        wheels_id=loadout.get("wheels_id", 0),
-        boost_id=loadout.get("boost_id", 0),
-        antenna_id=loadout.get("antenna_id", 0),
-        hat_id=loadout.get("hat_id", 0),
-        paint_finish_id=loadout.get("paint_finish_id", 0),
-        custom_finish_id=loadout.get("custom_finish_id", 0),
-        engine_audio_id=loadout.get("engine_audio_id", 0),
-        trails_id=loadout.get("trails_id", 0),
-        goal_explosion_id=loadout.get("goal_explosion_id", 0),
+        team_color_id=__int(loadout, "team_color_id"),
+        custom_color_id=__int(loadout, "custom_color_id"),
+        car_id=__int(loadout, "car_id"),
+        decal_id=__int(loadout, "decal_id"),
+        wheels_id=__int(loadout, "wheels_id"),
+        boost_id=__int(loadout, "boost_id"),
+        antenna_id=__int(loadout, "antenna_id"),
+        hat_id=__int(loadout, "hat_id"),
+        paint_finish_id=__int(loadout, "paint_finish_id"),
+        custom_finish_id=__int(loadout, "custom_finish_id"),
+        engine_audio_id=__int(loadout, "engine_audio_id"),
+        trails_id=__int(loadout, "trails_id"),
+        goal_explosion_id=__int(loadout, "goal_explosion_id"),
         loadout_paint=paint,
     )
 
@@ -170,30 +207,30 @@ def load_player_config(
     with open(path, "rb") as f:
         config = tomllib.load(f)
 
-    settings: dict[str, Any] = config["settings"]
+    settings = __table(config, "settings")
 
     root_dir = path.parent.absolute()
     if "root_dir" in settings:
-        root_dir /= Path(settings["root_dir"])
+        root_dir /= Path(__str(settings, "root_dir"))
 
-    run_command = settings.get("run_command", "")
+    run_command = __str(settings, "run_command")
     if CURRENT_OS == OS.LINUX and "run_command_linux" in settings:
-        run_command = settings.get("run_command_linux", "")
+        run_command = __str(settings, "run_command_linux")
 
-    loadout_path = path.parent / Path(settings["loadout_file"]) if "loadout_file" in settings else None
+    loadout_path = path.parent / Path(__str(settings, "loadout_file")) if "loadout_file" in settings else None
     loadout_path = loadout_override or loadout_path
     loadout = load_player_loadout(loadout_path, team) if loadout_path is not None else None
 
     return flat.PlayerConfiguration(
         type,
-        name_override or settings.get("name", ""),
+        name_override or __str(settings, "name"),
         team,
         str(root_dir),
         run_command,
         loadout,
         0,
-        settings.get("agent_id", ""),
-        settings.get("hivemind", False),
+        __str(settings, "agent_id"),
+        __bool(settings, "hivemind"),
     )
 
 
@@ -209,16 +246,16 @@ def load_script_config(path: Path | str) -> flat.ScriptConfiguration:
 
     root_dir = path.parent
     if "root_dir" in settings:
-        root_dir /= Path(settings["root_dir"])
+        root_dir /= Path(__str(settings, "root_dir"))
 
-    run_command = settings.get("run_command", "")
+    run_command = __str(settings, "run_command")
     if CURRENT_OS == OS.LINUX and "run_command_linux" in settings:
-        run_command = settings["run_command_linux"]
+        run_command = __str(settings, "run_command_linux")
 
     return flat.ScriptConfiguration(
-        settings.get("name", ""),
+        __str(settings, "name"),
         str(root_dir),
         run_command,
         0,
-        settings.get("agent_id", ""),
+        __str(settings, "agent_id"),
     )

--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -9,7 +9,7 @@ from rlbot.utils.os_detector import CURRENT_OS, OS
 
 def __parse_enum(table: dict, key: str, enum: Any, default: int = 0) -> Any:
     if key not in table:
-        return enum(0)
+        return enum(default)
     try:
         for i in range(100000):
             if str(enum(i)).split('.')[-1].lower() == table[key].lower():

--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -178,17 +178,18 @@ def load_player_config(
 
     run_command = settings.get("run_command", "")
     if CURRENT_OS == OS.LINUX and "run_command_linux" in settings:
-        run_command = settings["run_command_linux"]
+        run_command = settings.get("run_command_linux", "")
 
-    loadout_path = path.parent / Path(settings["loadout_file"]) if "loadout_file" in settings else loadout_override
+    loadout_path = path.parent / Path(settings["loadout_file"]) if "loadout_file" in settings else None
+    loadout_path = loadout_override or loadout_path
     loadout = load_player_loadout(loadout_path, team) if loadout_path is not None else None
 
     return flat.PlayerConfiguration(
         type,
-        settings.get("name", name_override or "Unnamed"),
+        name_override or settings.get("name"),
         team,
         str(root_dir),
-        str(run_command),
+        run_command,
         loadout,
         0,
         settings.get("agent_id", ""),

--- a/rlbot/config.py
+++ b/rlbot/config.py
@@ -186,7 +186,7 @@ def load_player_config(
 
     return flat.PlayerConfiguration(
         type,
-        name_override or settings.get("name"),
+        name_override or settings.get("name", ""),
         team,
         str(root_dir),
         run_command,
@@ -216,7 +216,7 @@ def load_script_config(path: Path | str) -> flat.ScriptConfiguration:
         run_command = settings["run_command_linux"]
 
     return flat.ScriptConfiguration(
-        settings.get("name", "Unnamed"),
+        settings.get("name", ""),
         str(root_dir),
         run_command,
         0,

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.24"
+__version__ = "2.0.0-beta.25"


### PR DESCRIPTION
This PR fixes and enhances the changes from https://github.com/VirxEC/python-interface/pull/17, making the match config parsing behave similar to core's https://github.com/RLBot/core/pull/72 (without the validation).

- Fixes enum defaults
- Fixes config overrides in cars entries
- Adds type checking
- Raises errors on bad enum values