### PR TITLE
Fix text rendering background color

### DIFF
--- a/rlbot/managers/rendering.py
+++ b/rlbot/managers/rendering.py
@@ -180,7 +180,7 @@ class Renderer:
         anchor: flat.RenderAnchor | flat.BallAnchor | flat.CarAnchor | flat.Vector3,
         scale: float,
         foreground: flat.Color,
-        background: flat.Color = flat.Color(),
+        background: flat.Color = flat.Color(a=0),
         h_align: flat.TextHAlign = flat.TextHAlign.Left,
         v_align: flat.TextVAlign = flat.TextVAlign.Top,
     ):
@@ -207,7 +207,7 @@ class Renderer:
         y: float,
         scale: float,
         foreground: flat.Color,
-        background: flat.Color = flat.Color(),
+        background: flat.Color = flat.Color(a=0),
         h_align: flat.TextHAlign = flat.TextHAlign.Left,
         v_align: flat.TextVAlign = flat.TextVAlign.Top,
     ):

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.30"
+__version__ = "2.0.0-beta.31"


### PR DESCRIPTION
Background color of text rendering turned black when we set alpha=255 by default.