### PR TITLE
Beta 49

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A high performance Python interface for communicating with RLBot 
 dynamic = ["version"]
 requires-python = ">= 3.11"
 dependencies = [
-    "rlbot_flatbuffers~=0.17.0",
+    "rlbot_flatbuffers~=0.18.2",
     "psutil==7.*",
 ]
 readme = "README.md"
@@ -26,7 +26,7 @@ version = {attr = "rlbot.version.__version__"}
 
 [dependency-groups]
 dev = [
-    "ruff>=0.12.5",
+    "ruff>=0.13.0",
     "toml>=0.10.2",
 ]
 

--- a/rlbot/managers/bot.py
+++ b/rlbot/managers/bot.py
@@ -1,6 +1,5 @@
 import os
 from traceback import print_exc
-from typing import Optional
 
 from rlbot import flat
 from rlbot.interface import (
@@ -12,8 +11,6 @@ from rlbot.interface import (
 from rlbot.managers.rendering import Renderer
 from rlbot.utils import fill_desired_game_state
 from rlbot.utils.logging import DEFAULT_LOGGER, get_logger
-
-WARNED_SPAWN_ID_DEPRECATED = False
 
 
 class Bot:
@@ -31,17 +28,6 @@ class Bot:
     index: int = -1
     name: str = ""
     player_id: int = 0
-
-    @property
-    def spawn_id(self) -> int:
-        global WARNED_SPAWN_ID_DEPRECATED
-        if not WARNED_SPAWN_ID_DEPRECATED:
-            WARNED_SPAWN_ID_DEPRECATED = True
-            self.logger.warning(
-                "'spawn_id' getter accessed, which is deprecated in favor of 'player_id'."
-            )
-
-        return self.player_id
 
     match_config = flat.MatchConfiguration()
     """
@@ -63,10 +49,10 @@ class Bot:
     _has_field_info = False
     _has_player_mapping = False
 
-    _latest_packet: Optional[flat.GamePacket] = None
+    _latest_packet: flat.GamePacket | None = None
     _latest_prediction = flat.BallPrediction()
 
-    def __init__(self, default_agent_id: Optional[str] = None):
+    def __init__(self, default_agent_id: str | None = None):
         agent_id = os.environ.get("RLBOT_AGENT_ID") or default_agent_id
 
         if agent_id is None:
@@ -107,7 +93,7 @@ class Bot:
             return
 
         for player in self.match_config.player_configurations:
-            match player.variety.item:
+            match player.variety:
                 case flat.CustomBot(name):
                     if player.player_id == self.player_id:
                         self.name = name
@@ -253,7 +239,7 @@ class Bot:
     def update_rendering_status(
         self,
         status: bool,
-        index: Optional[int] = None,
+        index: int | None = None,
         is_bot: bool = True,
     ):
         """
@@ -274,7 +260,7 @@ class Bot:
         index: int,
         team: int,
         content: bytes,
-        display: Optional[str],
+        display: str | None,
         team_only: bool,
     ):
         """
@@ -284,7 +270,7 @@ class Bot:
         """
 
     def send_match_comm(
-        self, content: bytes, display: Optional[str] = None, team_only: bool = False
+        self, content: bytes, display: str | None = None, team_only: bool = False
     ):
         """
         Emits a match communication message to other bots and scripts.
@@ -307,7 +293,7 @@ class Bot:
         self,
         balls: dict[int, flat.DesiredBallState] = {},
         cars: dict[int, flat.DesiredCarState] = {},
-        match_info: Optional[flat.DesiredMatchInfo] = None,
+        match_info: flat.DesiredMatchInfo | None = None,
         commands: list[str] = [],
     ):
         """
@@ -319,7 +305,7 @@ class Bot:
         game_state = fill_desired_game_state(balls, cars, match_info, commands)
         self._game_interface.send_msg(game_state)
 
-    def set_loadout(self, loadout: flat.PlayerLoadout, index: Optional[int] = None):
+    def set_loadout(self, loadout: flat.PlayerLoadout, index: int | None = None):
         """
         Sets the loadout of a bot.
         Can be used to select or generate a loadout for the match when called inside `initialize`.

--- a/rlbot/managers/hivemind.py
+++ b/rlbot/managers/hivemind.py
@@ -1,7 +1,6 @@
 import os
 from logging import Logger
 from traceback import print_exc
-from typing import Optional
 
 from rlbot import flat
 from rlbot.interface import (
@@ -13,8 +12,6 @@ from rlbot.interface import (
 from rlbot.managers import Renderer
 from rlbot.utils import fill_desired_game_state
 from rlbot.utils.logging import DEFAULT_LOGGER, get_logger
-
-WARNED_SPAWN_ID_DEPRECATED = False
 
 
 class Hivemind:
@@ -33,17 +30,6 @@ class Hivemind:
     indices: list[int] = []
     names: list[str] = []
     player_ids: list[int] = []
-
-    @property
-    def spawn_ids(self) -> list[int]:
-        global WARNED_SPAWN_ID_DEPRECATED
-        if not WARNED_SPAWN_ID_DEPRECATED:
-            WARNED_SPAWN_ID_DEPRECATED = True
-            self._logger.warning(
-                "'spawn_id' getter accessed, which is deprecated in favor of 'player_id'."
-            )
-
-        return self.player_ids
 
     match_config = flat.MatchConfiguration()
     """
@@ -65,10 +51,10 @@ class Hivemind:
     _has_field_info = False
     _has_player_mapping = False
 
-    _latest_packet: Optional[flat.GamePacket] = None
+    _latest_packet: flat.GamePacket | None = None
     _latest_prediction = flat.BallPrediction()
 
-    def __init__(self, default_agent_id: Optional[str] = None):
+    def __init__(self, default_agent_id: str | None = None):
         agent_id = os.environ.get("RLBOT_AGENT_ID") or default_agent_id
 
         if agent_id is None:
@@ -110,7 +96,7 @@ class Hivemind:
         # Search match configuration for our spawn ids
         for player_id in self.player_ids:
             for player in self.match_config.player_configurations:
-                match player.variety.item:
+                match player.variety:
                     case flat.CustomBot(name):
                         if player.player_id == player_id:
                             self.names.append(name)
@@ -251,7 +237,7 @@ class Hivemind:
     def update_rendering_status(
         self,
         status: bool,
-        index: Optional[int] = None,
+        index: int | None = None,
         is_bot: bool = True,
     ):
         """
@@ -283,7 +269,7 @@ class Hivemind:
         index: int,
         team: int,
         content: bytes,
-        display: Optional[str],
+        display: str | None,
         team_only: bool,
     ):
         """
@@ -296,7 +282,7 @@ class Hivemind:
         self,
         index: int,
         content: bytes,
-        display: Optional[str] = None,
+        display: str | None = None,
         team_only: bool = False,
     ):
         """
@@ -320,7 +306,7 @@ class Hivemind:
         self,
         balls: dict[int, flat.DesiredBallState] = {},
         cars: dict[int, flat.DesiredCarState] = {},
-        match_info: Optional[flat.DesiredMatchInfo] = None,
+        match_info: flat.DesiredMatchInfo | None = None,
         commands: list[str] = [],
     ):
         """

--- a/rlbot/managers/match.py
+++ b/rlbot/managers/match.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 from time import sleep
-from typing import Optional
 
 import psutil
 
@@ -17,14 +16,14 @@ class MatchManager:
     """
 
     logger = DEFAULT_LOGGER
-    packet: Optional[flat.GamePacket] = None
-    rlbot_server_process: Optional[psutil.Process] = None
+    packet: flat.GamePacket | None = None
+    rlbot_server_process: psutil.Process | None = None
     rlbot_server_port = RLBOT_SERVER_PORT
     initialized = False
 
     def __init__(
         self,
-        main_executable_path: Optional[Path] = None,
+        main_executable_path: Path | None = None,
         main_executable_name: str = MAIN_EXECUTABLE_NAME,
     ):
         self.main_executable_path = main_executable_path
@@ -76,7 +75,7 @@ class MatchManager:
         wants_ball_predictions: bool,
         close_between_matches: bool = True,
         rlbot_server_ip: str = RLBOT_SERVER_IP,
-        rlbot_server_port: Optional[int] = None,
+        rlbot_server_port: int | None = None,
     ):
         """
         Connects to the RLBot server specifying the given settings.
@@ -109,7 +108,7 @@ class MatchManager:
         wants_ball_predictions: bool,
         close_between_matches: bool = True,
         rlbot_server_ip: str = RLBOT_SERVER_IP,
-        rlbot_server_port: Optional[int] = None,
+        rlbot_server_port: int | None = None,
         background_thread: bool = False,
     ):
         """
@@ -184,7 +183,7 @@ class MatchManager:
         self,
         balls: dict[int, flat.DesiredBallState] = {},
         cars: dict[int, flat.DesiredCarState] = {},
-        match_info: Optional[flat.DesiredMatchInfo] = None,
+        match_info: flat.DesiredMatchInfo | None = None,
         commands: list[str] = [],
     ):
         """

--- a/rlbot/managers/rendering.py
+++ b/rlbot/managers/rendering.py
@@ -1,7 +1,6 @@
 import math
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager
-from typing import Optional
 
 from rlbot import flat
 from rlbot.interface import SocketRelay
@@ -51,7 +50,7 @@ class Renderer:
     _logger = get_logger("renderer")
 
     _used_group_ids: set[int] = set()
-    _group_id: Optional[int] = None
+    _group_id: int | None = None
     _current_renders: list[flat.RenderMessage] = []
 
     _default_color = white

--- a/rlbot/managers/script.py
+++ b/rlbot/managers/script.py
@@ -1,6 +1,5 @@
 import os
 from traceback import print_exc
-from typing import Optional
 
 from rlbot import flat
 from rlbot.interface import (
@@ -35,10 +34,10 @@ class Script:
     _has_match_settings = False
     _has_field_info = False
 
-    _latest_packet: Optional[flat.GamePacket] = None
+    _latest_packet: flat.GamePacket | None = None
     _latest_prediction = flat.BallPrediction()
 
-    def __init__(self, default_agent_id: Optional[str] = None):
+    def __init__(self, default_agent_id: str | None = None):
         agent_id = os.environ.get("RLBOT_AGENT_ID") or default_agent_id
 
         if agent_id is None:
@@ -200,7 +199,7 @@ class Script:
     def update_rendering_status(
         self,
         status: bool,
-        index: Optional[int] = None,
+        index: int | None = None,
         is_bot: bool = False,
     ):
         """
@@ -221,7 +220,7 @@ class Script:
         index: int,
         team: int,
         content: bytes,
-        display: Optional[str],
+        display: str | None,
         team_only: bool,
     ):
         """
@@ -231,7 +230,7 @@ class Script:
         """
 
     def send_match_comm(
-        self, content: bytes, display: Optional[str] = None, team_only: bool = False
+        self, content: bytes, display: str | None = None, team_only: bool = False
     ):
         """
         Emits a match communication message to other bots and scripts.
@@ -254,7 +253,7 @@ class Script:
         self,
         balls: dict[int, flat.DesiredBallState] = {},
         cars: dict[int, flat.DesiredCarState] = {},
-        match_info: Optional[flat.DesiredMatchInfo] = None,
+        match_info: flat.DesiredMatchInfo | None = None,
         commands: list[str] = [],
     ):
         """

--- a/rlbot/utils/__init__.py
+++ b/rlbot/utils/__init__.py
@@ -1,12 +1,10 @@
-from typing import Optional
-
 from rlbot import flat
 
 
 def fill_desired_game_state(
     balls: dict[int, flat.DesiredBallState] = {},
     cars: dict[int, flat.DesiredCarState] = {},
-    match_info: Optional[flat.DesiredMatchInfo] = None,
+    match_info: flat.DesiredMatchInfo | None = None,
     commands: list[str] = [],
 ) -> flat.DesiredGameState:
     """

--- a/rlbot/utils/gateway.py
+++ b/rlbot/utils/gateway.py
@@ -3,7 +3,6 @@ import socket
 import stat
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 import psutil
 
@@ -17,7 +16,7 @@ if CURRENT_OS != "Windows":
 
 def find_main_executable_path(
     main_executable_path: Path, main_executable_name: str
-) -> tuple[Path, Optional[Path]]:
+) -> tuple[Path, Path | None]:
     main_executable_path = main_executable_path.absolute().resolve()
 
     # check if the path is directly to the main executable
@@ -88,7 +87,7 @@ def launch(
 
 def find_server_process(
     main_executable_name: str,
-) -> tuple[Optional[psutil.Process], int]:
+) -> tuple[psutil.Process | None, int]:
     logger = DEFAULT_LOGGER
     for proc in psutil.process_iter():
         try:

--- a/rlbot/version.py
+++ b/rlbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.0.0-beta.48"
+__version__ = "2.0.0-beta.49"

--- a/tests/render_test/render.py
+++ b/tests/render_test/render.py
@@ -25,7 +25,7 @@ class RenderFun(Script):
 
             radius = 0
             if len(packet.balls) > 0:
-                match packet.balls[0].shape.item:
+                match packet.balls[0].shape:
                     case flat.SphereShape() | flat.CylinderShape() as shape:
                         radius = shape.diameter / 2
                     case flat.BoxShape() as shape:


### PR DESCRIPTION
Migration guide: <https://github.com/RLBot/python-interface/wiki/Migration#python-interface-beta-48-to-beta-49>

- Update `rlbot_flatbuffers` to v0.18
- Update `ruff` to v0.13
- Remove deprecated `spawn_id` aliases
